### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -155,8 +155,7 @@ client_secret = ""
 if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
-    print(
-        f"Created service token with client_id {client_id} and client_secret {client_secret}. You may want to save these secrets.")
+    print(f"Created service token with client_id {client_id}. Please save the client_secret securely.")
 
 
 if len(client_secret) == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3)

To fix the problem, we need to ensure that sensitive information such as `client_secret` is not logged in clear text. Instead of logging the actual `client_secret`, we can log a message indicating that a service token was created without revealing the sensitive details. This way, we maintain the functionality of informing the user about the creation of the service token without exposing sensitive information.

We will modify the code in `public/cloudflare-one/static/authenticated-doh.py` to remove the logging of `client_secret` and replace it with a more generic message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
