### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -8,6 +8,15 @@ from pprint import pprint
 
 verbose = os.environ.get('VERBOSE', False)
 
+def sanitize_command(command):
+    sanitized_command = []
+    for part in command:
+        if part.startswith('Cf-Access-Client-Secret:'):
+            sanitized_command.append('Cf-Access-Client-Secret: [REDACTED]')
+        else:
+            sanitized_command.append(part)
+    return sanitized_command
+
 
 def check_for_command(command):
     try:
@@ -69,7 +78,8 @@ def request_doh_token(account_tag, user_id, client_id, client_secret):
                '-H', f"Cf-Access-Client-Id: {client_id}",
                '-H', f"Cf-Access-Client-Secret: {client_secret}"]
     if verbose:
-        print(f"Issuing request {' '.join(command)}")
+        sanitized_command = sanitize_command(command)
+        print(f"Issuing request {' '.join(sanitized_command)}")
     response = json.loads(subprocess.check_output(command))
     if verbose:
         print("Got response:")


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/1](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as `client_secret` is not logged in clear text. Instead of logging the entire command, we can log a sanitized version of it that excludes the sensitive information. This way, we can still have useful logging for debugging purposes without exposing sensitive data.

We will modify the logging statement on line 72 to exclude the `client_secret` from the logged command. We will also add a helper function to sanitize the command before logging it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
