### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -155,8 +155,7 @@ client_secret = ""
 if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
-    print(
-        f"Created service token with client_id {client_id} and client_secret {client_secret}. You may want to save these secrets.")
+    print("Created service token. Please save the client_id and client_secret securely.")
 
 
 if len(client_secret) == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3)

To fix the problem, we need to ensure that sensitive information such as `client_secret` is not logged in clear text. Instead, we can log a message indicating that a service token was created without including the sensitive details. This way, we maintain the functionality of informing the user that a token was created while protecting sensitive information.

We will modify the code on line 159 to remove the logging of `client_secret` and replace it with a more generic message. Additionally, we will ensure that `client_id` is not logged if it is considered sensitive.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
