### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -146,8 +146,7 @@ client_secret = ""
 if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
-    print(
-        f"Created service token with client_id {client_id} and client_secret {client_secret}. You may want to save these secrets.")
+    print(f"Created service token with client_id {client_id}. Please save the client_id and client_secret securely.")
 
 
 if len(client_secret) == 0:

--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -146,7 +146,7 @@ client_secret = ""
 if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
-    print(f"Created service token with client_id {client_id}. Please save the client_id and client_secret securely.")
+    print("Created service token. Please save the client_id and client_secret securely.")
 
 
 if len(client_secret) == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3)

To fix the problem, we need to avoid logging the `client_secret` in clear text. Instead, we can log a message indicating that the service token was created without including the sensitive information. This way, we maintain the functionality of informing the user that the token was created while ensuring that sensitive data is not exposed.

We will modify the print statement on line 150 to exclude the `client_secret`. We will also add a note to the user to save the secrets without logging them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
