### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -146,7 +146,7 @@ if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
     print(
-        f"Created service token with client_id {client_id} and client_secret {client_secret}. You may want to save these secrets.")
+        f"Created service token with client_id {client_id}. Please save the client_secret securely.")
 
 
 if len(client_secret) == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3)

To fix the problem, we need to ensure that sensitive information such as `client_secret` is not logged in clear text. Instead, we can log a message indicating that a service token was created without including the sensitive details. This way, we maintain the functionality of informing the user about the creation of the service token without exposing sensitive information.

We will modify the logging statement on line 149 to exclude the `client_secret`. We will also ensure that any other sensitive information is not logged in clear text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
