### PR TITLE
Potential fix for code scanning alert no. 26: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -145,8 +145,7 @@ client_secret = ""
 if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
-    print(
-        f"Created service token with client_id {client_id}. Please save the client_secret securely.")
+    print("Created service token. Please save the client_secret securely.")
 
 
 if len(client_secret) == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/26](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/26)

To fix the problem, we need to ensure that sensitive information such as `client_id` and `client_secret` is not logged in clear text. Instead, we can log a message indicating that a service token was created without including the sensitive details. This can be achieved by modifying the log message on line 149 to exclude the `client_id` and `client_secret`.

We will replace the log message with a more generic message that does not include sensitive information. This change will be made in the file `public/cloudflare-one/static/authenticated-doh.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
