### PR TITLE
Potential fix for code scanning alert no. 26: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -146,8 +146,7 @@ client_secret = ""
 if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
-    print(
-        f"Created service token with client_id {client_id}. Please save the client_secret securely.")
+    print("Created service token. Please save the client_secret securely.")
 
 
 if len(client_secret) == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/26](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/26)

To fix the problem, we need to ensure that sensitive information such as `client_id` and `client_secret` is not logged in clear text. Instead, we can log a generic message indicating that a service token was created without including the sensitive details. This way, we maintain the functionality of informing the user about the creation of the service token without exposing sensitive data.

We will modify the log message on line 150 to remove the `client_id` and avoid logging the `client_secret`. The new log message will simply inform the user that a service token was created and remind them to save the client secret securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
