### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -69,7 +69,8 @@ def request_doh_token(account_tag, user_id, client_id, client_secret):
                '-H', f"Cf-Access-Client-Id: {client_id}",
                '-H', f"Cf-Access-Client-Secret: {client_secret}"]
     if verbose:
-        print(f"Issuing request {' '.join(command)}")
+        sanitized_command = [part if "Cf-Access-Client-Secret" not in part else "Cf-Access-Client-Secret: [REDACTED]" for part in command]
+        print(f"Issuing request {' '.join(sanitized_command)}")
     response = json.loads(subprocess.check_output(command))
     if verbose:
         print("Got response:")


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/1](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as `client_secret` is not logged in clear text. Instead of logging the entire command, we can log a sanitized version of it that omits the sensitive parts. This way, we maintain the ability to debug without exposing sensitive data.

- Identify the line where the sensitive data is being logged.
- Modify the logging statement to exclude or mask the sensitive information.
- Ensure that the fix does not alter the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
