### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -69,7 +69,8 @@ def request_doh_token(account_tag, user_id, client_id, client_secret):
                '-H', f"Cf-Access-Client-Id: {client_id}",
                '-H', f"Cf-Access-Client-Secret: {client_secret}"]
     if verbose:
-        print(f"Issuing request {' '.join(command)}")
+        sanitized_command = [part if 'Cf-Access-Client-Secret' not in part else 'Cf-Access-Client-Secret: [REDACTED]' for part in command]
+        print(f"Issuing request {' '.join(sanitized_command)}")
     response = json.loads(subprocess.check_output(command))
     if verbose:
         print("Got response:")


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/1](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as `client_secret` is not logged in clear text. Instead of logging the entire command, we can log a sanitized version that omits the sensitive parts. This can be achieved by replacing the sensitive values with placeholders or by not logging them at all.

The best way to fix this without changing existing functionality is to modify the logging statement on line 72 to exclude the `client_secret`. We can create a sanitized version of the command that replaces the `client_secret` with a placeholder before logging it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
