### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/public/cloudflare-one/static/authenticated-doh.py
+++ b/public/cloudflare-one/static/authenticated-doh.py
@@ -146,8 +146,7 @@ client_secret = ""
 if client_id == "new":
     service_token_name = input('Please input name for service token > ')
     client_id, client_secret = request_create_service_token(service_token_name)
-    print(
-        f"Created service token with client_id {client_id} and client_secret {client_secret}. You may want to save these secrets.")
+    print("Created service token. Please save the client_id and client_secret securely.")
 
 
 if len(client_secret) == 0:


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3](https://github.com/krishnprakash/cloudflare-docs/security/code-scanning/3)

To fix the problem, we need to avoid logging sensitive information such as `client_id` and `client_secret`. Instead, we can log a message indicating that the service token was created without including the sensitive details. This way, we maintain the functionality of informing the user about the creation of the service token without exposing sensitive data.

- Modify the log message on line 150 to exclude `client_id` and `client_secret`.
- Ensure that the new log message still provides useful information without compromising security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
